### PR TITLE
Added FlexibleContexts

### DIFF
--- a/src/Data/Url.hs
+++ b/src/Data/Url.hs
@@ -6,6 +6,7 @@
   , OverloadedLists
   , QuasiQuotes
   , FlexibleInstances
+  , FlexibleContexts
   , StandaloneDeriving
   , TypeSynonymInstances
   , UndecidableInstances


### PR DESCRIPTION
I added this because the package would not compile. Fixes the following compilation error:
```
src/Data/Url.hs:252:19: error:
    • Non type-variable argument in the constraint: MonadBase IO m
      (Use FlexibleContexts to permit this)
    • In the stand-alone deriving instance for
        ‘(MonadResource m, MonadBase IO m) =>
         MonadResource (GroundedUrlT m)’
    |
252 | deriving instance (MonadResource m, MonadBase IO m) => MonadResource (GroundedUrlT m)
```